### PR TITLE
PIPEDEV-110: move Maya engine from config into a separate repo (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)
 
 ## Documentation
-This repository is a part of the ShotGrid Pipeline Toolkit.
+This repository is a part of the Flow Production Tracking Toolkit.
 
 - For more information about this app and for release notes, *see the wiki section*.
 - For general information and documentation, click here: https://help.autodesk.com/view/SGDEV/ENU/?contextId=SA_INTEGRATIONS_USER_GUIDE
-- For information about ShotGrid in general, click here: https://www.autodesk.com/products/shotgrid/overview
+- For information about Flow Production Tracking in general, click here: https://www.autodesk.com/products/flow-production-tracking/overview
 
 ## Using this app in your Setup
 All the apps that are part of our standard app suite are pushed to our App Store.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![VFX Platform](https://img.shields.io/badge/vfxplatform-2023%202022%202021%202020-blue.svg)](http://www.vfxplatform.com/)
+[![Python 3.7 3.9 3.10](https://img.shields.io/badge/python-3.7%20%7C%203.9%20%7C%203.10-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-maya?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=28&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![VFX Platform](https://img.shields.io/badge/vfxplatform-2023%202022%202021%202020-blue.svg)](http://www.vfxplatform.com/)
-[![Python 3.7 3.9 3.10](https://img.shields.io/badge/python-3.7%20%7C%203.9%20%7C%203.10-blue.svg)](https://www.python.org/)
+[![VFX Platform](https://img.shields.io/badge/vfxplatform-2024%20%7C%202023%20%7C%202022%20%7C%202021-blue.svg)](http://www.vfxplatform.com/)
+[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.10%20%7C%203.9%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-maya?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=28&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 This repository is a part of the ShotGrid Pipeline Toolkit.
 
 - For more information about this app and for release notes, *see the wiki section*.
-- For general information and documentation, click here: https://developer.shotgridsoftware.com/d587be80/?title=Integrations+User+Guide
-- For information about ShotGrid in general, click here: https://www.shotgridsoftware.com/integrations
+- For general information and documentation, click here: https://help.autodesk.com/view/SGDEV/ENU/?contextId=SA_INTEGRATIONS_USER_GUIDE
+- For information about ShotGrid in general, click here: https://www.autodesk.com/products/shotgrid/overview
 
 ## Using this app in your Setup
 All the apps that are part of our standard app suite are pushed to our App Store.
 This is where you typically go if you want to install an app into a project you are
 working on. For an overview of all the Apps and Engines in the Toolkit App Store,
-click here: https://developer.shotgridsoftware.com/162eaa4b/?title=Pipeline+Integration+Components
+click here: https://help.autodesk.com/view/SGDEV/ENU/?contextId=PC_TOOLKIT_APPS
 
 ## Have a Question?
-Don't hesitate to contact us! You can find us on https://knowledge.autodesk.com/contact-support
+Don't hesitate to contact us at https://knowledge.autodesk.com/contact-support

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python 2.6 2.7 3.7](https://img.shields.io/badge/python-2.6%20%7C%202.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-maya?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=28&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Security
+
+At Autodesk, we know that the security of your data is critical to your studio’s
+operation.
+As the industry shifts to the cloud, ShotGrid knows that security and service
+models are more important than ever.
+
+The confidentiality, integrity, and availability of your content is at the top
+of our priority list.
+Not only do we have a team of ShotGrid engineers dedicated to platform security
+and performance, we are also backed by Autodesk’s security team, also invests
+heavily in the security for broad range of industries and customers.
+We constantly reassess, develop, and improve our risk management program because
+we know that the landscape of security is ever-changing.
+
+If you believe you have found a security vulnerability in any ShotGrid-owned
+repository, please report it to us as described below.
+
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them by sending a message to
+[Autodesk Trust Center](https://www.autodesk.com/trust/contact-us).
+
+Please include as much information as you can provide such as locations,
+configurations, reproduction steps, exploit code, impact, etc.
+
+
+## Additional Information
+
+Please check out the [ShotGrid Security White Paper](https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Administrator_ar_general_security_ar_security_white_paper_html).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,18 +4,18 @@
 
 At Autodesk, we know that the security of your data is critical to your studio’s
 operation.
-As the industry shifts to the cloud, ShotGrid knows that security and service
+As the industry shifts to the cloud, Flow Production Tracking knows that security and service
 models are more important than ever.
 
 The confidentiality, integrity, and availability of your content is at the top
 of our priority list.
-Not only do we have a team of ShotGrid engineers dedicated to platform security
+Not only do we have a team of Flow Production Tracking engineers dedicated to platform security
 and performance, we are also backed by Autodesk’s security team, also invests
 heavily in the security for broad range of industries and customers.
 We constantly reassess, develop, and improve our risk management program because
 we know that the landscape of security is ever-changing.
 
-If you believe you have found a security vulnerability in any ShotGrid-owned
+If you believe you have found a security vulnerability in any Flow Production Tracking-owned
 repository, please report it to us as described below.
 
 
@@ -32,4 +32,4 @@ configurations, reproduction steps, exploit code, impact, etc.
 
 ## Additional Information
 
-Please check out the [ShotGrid Security White Paper](https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Administrator_ar_general_security_ar_security_white_paper_html).
+Please check out the [Flow Production Tracking Security White Paper](https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Administrator_ar_general_security_ar_security_white_paper_html).

--- a/engine.py
+++ b/engine.py
@@ -384,7 +384,18 @@ class MayaEngine(Engine):
         if maya_ver.startswith("Maya "):
             maya_ver = maya_ver[5:]
         if maya_ver.startswith(
-            ("2014", "2015", "2016", "2017", "2018", "2019", "2020", "2022", "2023")
+            (
+                "2014",
+                "2015",
+                "2016",
+                "2017",
+                "2018",
+                "2019",
+                "2020",
+                "2022",
+                "2023",
+                "2024",
+            )
         ):
             self.logger.debug("Running Maya version %s", maya_ver)
 

--- a/engine.py
+++ b/engine.py
@@ -857,9 +857,11 @@ class MayaEngine(Engine):
         proj_path = tmpl.apply_fields(fields)
         self.logger.info("Setting Maya project to '%s'", proj_path)
 
-        # Since we are inserting this path into another string that will be executed in mel
-        # We need to double up and backslashes.
-        proj_path = proj_path.replace("\\", "\\\\")
+        try:
+            cmds.workspace(proj_path, openWorkspace=True)
+        except RuntimeError as e:
+            self.logger.error("Maya failed to open Project. Error: %s", str(e))
+            raise e
 
         cmds.workspace(proj_path, openWorkspace=True)
 

--- a/engine.py
+++ b/engine.py
@@ -178,7 +178,9 @@ def refresh_engine(engine_name, prev_context, menu_name):
 
     except sgtk.TankError as e:
         logger.exception("Could not execute sgtk_from_path('%s')" % new_path)
-        OpenMaya.MGlobal.displayInfo("ShotGrid: Engine cannot be started: %s" % e)
+        OpenMaya.MGlobal.displayInfo(
+            "Flow Production Tracking: Engine cannot be started: %s" % e
+        )
         # build disabled menu
         create_sgtk_disabled_menu(menu_name)
         return
@@ -209,7 +211,7 @@ def on_scene_event_callback(engine_name, prev_context, menu_name):
         logger.exception("Could not refresh the engine; error: '%s'" % e)
         (exc_type, exc_value, exc_traceback) = sys.exc_info()
         message = ""
-        message += "Message: SG encountered a problem changing the Engine's context.\n"
+        message += "Message: PTR encountered a problem changing the Engine's context.\n"
         message += "Please contact %s\n\n" % sgtk.support_url
         message += "Exception: %s - %s\n" % (exc_type, exc_value)
         message += "Traceback (most recent call last):\n"
@@ -222,7 +224,7 @@ def sgtk_disabled_message():
     Explain why sgtk is disabled.
     """
     msg = (
-        "SG integration is disabled because it cannot recognize "
+        "PTR integration is disabled because it cannot recognize "
         "the currently opened file.  Try opening another file or restarting "
         "Maya."
     )
@@ -239,7 +241,7 @@ def sgtk_disabled_message():
 
 def create_sgtk_disabled_menu(menu_name):
     """
-    Render a special "SG is disabled" menu
+    Render a special "PTR is disabled" menu
     """
     if cmds.about(batch=True):
         # don't create menu in batch mode
@@ -268,7 +270,7 @@ def create_sgtk_disabled_menu(menu_name):
 
 def remove_sgtk_disabled_menu():
     """
-    Remove the special "SG is disabled" menu if it exists
+    Remove the special "PTR is disabled" menu if it exists
 
     :returns: True if the menu existed and was deleted
     """
@@ -415,12 +417,14 @@ class MayaEngine(Engine):
             # older than 2014 doesn't ship with PySide. Instead, we just have to
             # raise an exception so that we bail out here with an error message
             # that will hopefully make sense for the user.
-            msg = "SG integration is not compatible with Maya versions older than 2014."
+            msg = (
+                "PTR integration is not compatible with Maya versions older than 2014."
+            )
             raise sgtk.TankError(msg)
         else:
             # show a warning that this version of Maya isn't yet fully tested with Shotgun:
             msg = (
-                "The SG Pipeline Toolkit has not yet been fully tested with Maya %s.  "
+                "The Flow Production Tracking has not yet been fully tested with Maya %s.  "
                 "You can continue to use Toolkit but you may experience bugs or instability."
                 "\n\nPlease report any issues to: %s" % (maya_ver, sgtk.support_url)
             )
@@ -444,7 +448,7 @@ class MayaEngine(Engine):
 
             if show_warning_dlg:
                 # Note, title is padded to try to ensure dialog isn't insanely narrow!
-                title = "Warning - SG Pipeline Toolkit Compatibility!                          "  # padded!
+                title = "Warning - Flow Production Tracking Compatibility!                          "  # padded!
                 cmds.confirmDialog(title=title, message=msg, button="Ok")
 
             # always log the warning to the script editor:
@@ -469,7 +473,7 @@ class MayaEngine(Engine):
 
         # default menu name is Shotgun but this can be overriden
         # in the configuration to be Sgtk in case of conflicts
-        self._menu_name = "ShotGrid"
+        self._menu_name = "Flow Production Tracking"
         if self.get_setting("use_sgtk_as_menu_name", False):
             self._menu_name = "Sgtk"
 
@@ -824,9 +828,9 @@ class MayaEngine(Engine):
         # where "basename" is the leaf part of the logging record name,
         # for example "tk-multi-shotgunpanel" or "qt_importer".
         if record.levelno < logging.INFO:
-            formatter = logging.Formatter("Debug: SG %(basename)s: %(message)s")
+            formatter = logging.Formatter("Debug: PTR %(basename)s: %(message)s")
         else:
-            formatter = logging.Formatter("SG %(basename)s: %(message)s")
+            formatter = logging.Formatter("PTR %(basename)s: %(message)s")
 
         msg = formatter.format(record)
 

--- a/engine.py
+++ b/engine.py
@@ -850,7 +850,7 @@ class MayaEngine(Engine):
         # We need to double up and backslashes.
         proj_path = proj_path.replace("\\", "\\\\")
 
-        mel.eval('setProject("{0}")'.format(proj_path))
+        cmds.workspace(proj_path, openWorkspace=True)
 
     ##########################################################################################
     # panel support

--- a/engine.py
+++ b/engine.py
@@ -177,13 +177,21 @@ def refresh_engine(engine_name, prev_context, menu_name):
         logger.debug("Extracted sgtk instance: '%r' from path: '%r'", tk, new_path)
 
     except sgtk.TankError as e:
-        logger.exception("Could not execute sgtk_from_path('%s')" % new_path)
-        OpenMaya.MGlobal.displayInfo(
-            "Flow Production Tracking: Engine cannot be started: %s" % e
-        )
-        # build disabled menu
-        create_sgtk_disabled_menu(menu_name)
-        return
+        if prev_context.project:
+            logger.warn('Falling back to project context `{prev_context}` ' \
+                        'because the scene file path is unknown.'.format(prev_context=prev_context))
+            tk = sgtk.sgtk_from_entity('Project', prev_context.project['id'])
+            ctx = tk.context_from_entity('Project', prev_context.project['id'])
+            current_engine.change_context(ctx)
+            return
+        else:
+            logger.exception("Could not execute sgtk_from_path('%s')" % new_path)
+            OpenMaya.MGlobal.displayInfo(
+                "Flow Production Tracking: Engine cannot be started: %s" % e
+            )
+            # build disabled menu
+            create_sgtk_disabled_menu(menu_name)
+            return
 
     # shotgun menu may have been removed, so add it back in if its not already there.
     current_engine.create_shotgun_menu()

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -346,8 +346,7 @@ class MayaSessionPublishPlugin(HookBaseClass):
         # do the base class finalization
         super(MayaSessionPublishPlugin, self).finalize(settings, item)
 
-        # bump the session file to the next version
-        self._save_to_next_version(item.properties["path"], item, _save_session)
+        self._save_to_next_version(item.get_property("path"), item, _save_session)
 
 
 def _maya_find_additional_session_dependencies():

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -42,8 +42,8 @@ class MayaSessionPublishPlugin(HookBaseClass):
         loader_url = "https://help.autodesk.com/view/SGDEV/ENU/?contextId=PC_APP_LOADER"
 
         return """
-        Publishes the file to ShotGrid. A <b>Publish</b> entry will be
-        created in ShotGrid which will include a reference to the file's current
+        Publishes the file to Flow Production Tracking. A <b>Publish</b> entry will be
+        created in Flow Production Tracking which will include a reference to the file's current
         path on disk. If a publish template is configured, a copy of the
         current session will be copied to the publish template path which
         will be the file that is published. Other users will be able to access
@@ -58,7 +58,7 @@ class MayaSessionPublishPlugin(HookBaseClass):
         file to the next version after publishing.
 
         The <code>version</code> field of the resulting <b>Publish</b> in
-        ShotGrid will also reflect the version number identified in the filename.
+        Flow Production Tracking will also reflect the version number identified in the filename.
         The basic worklfow recognizes the following version formats by default:
 
         <ul>

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -39,7 +39,7 @@ class MayaSessionPublishPlugin(HookBaseClass):
         contain simple html for formatting.
         """
 
-        loader_url = "https://developer.shotgridsoftware.com/a4c0a4f1/?title=Loader"
+        loader_url = "https://help.autodesk.com/view/SGDEV/ENU/?contextId=PC_APP_LOADER"
 
         return """
         Publishes the file to ShotGrid. A <b>Publish</b> entry will be

--- a/info.yml
+++ b/info.yml
@@ -71,7 +71,7 @@ configuration:
 
     use_sgtk_as_menu_name:
         type: bool
-        description: Optionally choose to use 'Sgtk' as the primary menu name instead of 'ShotGrid'
+        description: Optionally choose to use 'Sgtk' as the primary menu name instead of 'Flow Production Tracking'
         default_value: false
 
     launch_builtin_plugins:
@@ -88,8 +88,8 @@ configuration:
 requires_shotgun_fields:
 
 # More verbose description of this item
-display_name: "ShotGrid Engine for Maya"
-description: "ShotGrid Integration in Maya"
+display_name: "Flow Production Tracking Engine for Maya"
+description: "Flow Production Tracking Integration in Maya"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:

--- a/plugins/basic/README.md
+++ b/plugins/basic/README.md
@@ -1,7 +1,7 @@
 # Maya Basic Toolkit workflow plugin
 
-This is a ShotGrid Pipeline Toolkit plugin,
-embedding the ShotGrid Pipeline Toolkit and allowing
+This is a Flow Production Tracking plugin,
+embedding the Flow Production Tracking and allowing
 you to easily run and deploy Toolkit Apps and Engines.
 
 The plugin will appear as `shotgun.py` inside of Maya
@@ -15,7 +15,7 @@ via the toolkit launch application, or as a standalone plugin.
 
 ### Technical Details
 
-This is a Maya Module that enables basic ShotGrid integration
+This is a Maya Module that enables basic Flow Production Tracking integration
 inside Maya. The plugin source is located in the [toolkit maya engine repository](https://github.com/shotgunsoftware/tk-maya/tree/develop/plugin/plugins/basic).
 Maya version 2014 and above are supported.
 You can read more about maya modules [here](http://help.autodesk.com/view/MAYAUL/2017/ENU/?guid=__files_GUID_CB76E356_753B_4837_8C5B_3296C14872CA_htm).

--- a/plugins/basic/README.md
+++ b/plugins/basic/README.md
@@ -122,4 +122,4 @@ you may find the following resources useful:
 - The plugin needs to be built before it can be executed. You do this by
   executing the build tools found [here](https://github.com/shotgunsoftware/tk-core/blob/master/developer).
 
-- For more information about Toolkit, see http://developer.shotgridsoftware.com/
+- For more information about Toolkit, see https://help.autodesk.com/view/SGDEV/ENU/

--- a/plugins/basic/plug-ins/shotgun.py
+++ b/plugins/basic/plug-ins/shotgun.py
@@ -36,7 +36,7 @@ def initializePlugin(mobject):
     # Make sure the plug-in is running in Maya 2014 or later.
     maya_version = mel.eval("getApplicationVersionAsFloat()")
     if maya_version < 2014:
-        msg = "The SG plug-in is not compatible with version %s of Maya; it requires Maya 2014 or later."
+        msg = "The PTR plug-in is not compatible with version %s of Maya; it requires Maya 2014 or later."
         OpenMaya2.MGlobal.displayError(msg % maya_version)
         # Ask Maya to unload the plug-in after returning from here.
         maya.utils.executeDeferred(cmds.unloadPlugin, PLUGIN_FILENAME)
@@ -52,9 +52,7 @@ def initializePlugin(mobject):
         import sgtk
 
         if sgtk.platform.current_engine():
-            msg = (
-                "The SG plug-in cannot be loaded because SG Toolkit is already running."
-            )
+            msg = "The PTR plug-in cannot be loaded because Flow Production Tracking is already running."
             OpenMaya2.MGlobal.displayError(msg)
             # Ask Maya to unload the plug-in after returning from here.
             maya.utils.executeDeferred(cmds.unloadPlugin, PLUGIN_FILENAME)

--- a/plugins/basic/python/tk_maya_basic/plugin_engine.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_engine.py
@@ -112,11 +112,11 @@ def shutdown():
     engine = sgtk.platform.current_engine()
 
     if engine:
-        logger.info("Stopping the SG engine.")
+        logger.info("Stopping the PTR engine.")
         # Close the various windows (dialogs, panels, etc.) opened by the engine.
         engine.close_windows()
         # Turn off your engine! Step away from the car!
         engine.destroy()
 
     else:
-        logger.debug("The SG engine was already stopped!")
+        logger.debug("The PTR engine was already stopped!")

--- a/plugins/basic/python/tk_maya_basic/plugin_logic.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logic.py
@@ -37,7 +37,7 @@ QtGui = qt_importer.QtGui
 from . import plugin_engine
 
 MENU_LOGIN = "ShotGridMenuLogin"
-MENU_LABEL = "ShotGrid"
+MENU_LABEL = "Flow Production Tracking"
 
 logger = sgtk.LogManager.get_logger(__name__)
 
@@ -91,7 +91,7 @@ class ProgressHandler(QtCore.QObject):
         :param message: Progress message to report.
         """
 
-        logger.debug("Bootstrapping ShotGrid: %s" % message)
+        logger.debug("Bootstrapping Flow Production Tracking: %s" % message)
 
         # Set some state that will trigger our timer to update the progress bar.
         self._progress_value = progress_value
@@ -140,7 +140,7 @@ def _login_user():
     except sgtk.authentication.AuthenticationCancelled:
         # When the user cancelled the Shotgun login dialog,
         # keep around the displayed login menu.
-        OpenMaya.MGlobal.displayInfo("SG login was cancelled by the user.")
+        OpenMaya.MGlobal.displayInfo("PTR login was cancelled by the user.")
         return
 
     # Get rid of the displayed login menu since the engine menu will take over.
@@ -148,7 +148,7 @@ def _login_user():
     # processed before deleting the menu to avoid a crash in Maya 2017.
     maya.utils.executeDeferred(_delete_login_menu)
 
-    OpenMaya.MGlobal.displayInfo("Loading SG integration...")
+    OpenMaya.MGlobal.displayInfo("Loading PTR integration...")
 
     # Show a progress bar, and set its initial value and message.
     _show_progress_bar(0.0, "Loading...")
@@ -166,7 +166,7 @@ def _login_user():
         # return to normal state
         _handle_bootstrap_failed(phase=None, exception=e)
         # also print the full call stack
-        logger.exception("SG reported the following exception during startup:")
+        logger.exception("PTR reported the following exception during startup:")
 
 
 def _handle_bootstrap_completed(engine):
@@ -195,7 +195,9 @@ def _handle_bootstrap_completed(engine):
     # running as a standalone plugin
     if sgtk.platform.current_engine().context.project is None:
         sgtk.platform.current_engine().register_command(
-            "Log Out of ShotGrid", _logout_user, {"type": "context_menu"}
+            "Log Out of Flow Production Tracking",
+            _logout_user,
+            {"type": "context_menu"},
         )
 
 
@@ -225,12 +227,12 @@ def _handle_bootstrap_failed(phase, exception):
     # the message displayed last will be the one visible in the script editor,
     # so make sure this is the error message summary.
     OpenMaya.MGlobal.displayError(
-        "An exception was raised during SG startup: %s" % exception
+        "An exception was raised during PTR startup: %s" % exception
     )
     OpenMaya.MGlobal.displayError(
         "For details, see log files in %s" % sgtk.LogManager().log_folder
     )
-    OpenMaya.MGlobal.displayError("Error loading SG integration.")
+    OpenMaya.MGlobal.displayError("Error loading PTR integration.")
 
     # Clear the user's credentials to log him/her out.
     sgtk.authentication.ShotgunAuthenticator().clear_default_user()
@@ -271,7 +273,7 @@ def _show_progress_bar(progress_value, message):
         isMainProgressBar=True,
         isInterruptable=False,
         progress=int(progress_value * 100.0),
-        status="ShotGrid: %s" % message,
+        status="Flow Production Tracking: %s" % message,
     )
 
 
@@ -309,7 +311,9 @@ def _create_login_menu():
 
     # Add the login menu item.
     cmds.menuItem(
-        parent=menu, label="Log In to ShotGrid...", command=Callback(_login_user)
+        parent=menu,
+        label="Log In to Flow Production Tracking...",
+        command=Callback(_login_user),
     )
 
     cmds.menuItem(parent=menu, divider=True)
@@ -317,12 +321,12 @@ def _create_login_menu():
     # Add the website menu items.
     cmds.menuItem(
         parent=menu,
-        label="Learn about ShotGrid...",
+        label="Learn about Flow Production Tracking...",
         command=Callback(_jump_to_website),
     )
     cmds.menuItem(
         parent=menu,
-        label="Try SG for Free...",
+        label="Try PTR for Free...",
         command=Callback(_jump_to_signup),
     )
 

--- a/python/tk_maya/menu_generation.py
+++ b/python/tk_maya/menu_generation.py
@@ -115,7 +115,7 @@ class MenuGenerator(object):
 
         # link to UI
         cmds.menuItem(
-            label="Jump to ShotGrid",
+            label="Jump to Flow Production Tracking",
             parent=ctx_menu,
             command=Callback(self._jump_to_sg),
         )

--- a/python/tk_maya/menu_generation.py
+++ b/python/tk_maya/menu_generation.py
@@ -248,7 +248,24 @@ class AppCommand(Callback):
         self.name = name
         self.properties = command_dict["properties"]
         self.favourite = False
-        super(AppCommand, self).__init__(command_dict["callback"])
+        self._callback = command_dict["callback"]
+
+        super(AppCommand, self).__init__(self._show_existing_window_or_run_callback)
+
+
+    def _show_existing_window_or_run_callback(self, *a, **kwa):
+        display_name = 'ShotGrid: ' + self.name.rstrip(' .')
+        tops = QtGui.QApplication.topLevelWidgets()
+        for top in tops:
+            if top.isWindow() and \
+               display_name in top.windowTitle() and \
+               top.__class__.__name__ == 'TankQDialog':
+                top.show()
+                top.activateWindow()
+                return None
+
+        return self._callback(*a, **kwa)
+
 
     def get_app_name(self):
         """

--- a/python/tk_maya/panel_generation.py
+++ b/python/tk_maya/panel_generation.py
@@ -104,7 +104,7 @@ def dock_panel(engine, shotgun_panel, title):
 
         # Reparent the Shotgun app panel under the Maya window layout.
         engine.logger.debug(
-            "Reparenting SG app panel %s under Maya layout %s.",
+            "Reparenting PTR app panel %s under Maya layout %s.",
             shotgun_panel_name,
             maya_layout,
         )
@@ -216,12 +216,12 @@ def dock_panel(engine, shotgun_panel, title):
             "        try:\n"
             "            sys.modules[m].build_workspace_control_ui('%(panel_name)s')\n"
             "        except Exception as e:\n"
-            "            msg = 'ShotGrid: Cannot restore %(panel_name)s: %%s' %% e\n"
+            "            msg = 'Flow Production Tracking: Cannot restore %(panel_name)s: %%s' %% e\n"
             "            fct = maya.api.OpenMaya.MGlobal.displayError\n"
             "            maya.utils.executeInMainThreadWithResult(fct, msg)\n"
             "        break\n"
             "else:\n"
-            "    msg = 'SG: Cannot restore %(panel_name)s: SG is not currently running'\n"
+            "    msg = 'PTR: Cannot restore %(panel_name)s: PTR is not currently running'\n"
             "    fct = maya.api.OpenMaya.MGlobal.displayError\n"
             "    maya.utils.executeInMainThreadWithResult(fct, msg)\n"
             % {"panel_name": shotgun_panel_name}
@@ -286,7 +286,7 @@ def build_workspace_control_ui(shotgun_panel_name):
             maya_panel_name = workspace_control.objectName()
 
             engine.logger.debug(
-                "Reparenting SG app panel %s under Maya workspace panel %s.",
+                "Reparenting PTR app panel %s under Maya workspace panel %s.",
                 shotgun_panel_name,
                 maya_panel_name,
             )
@@ -363,7 +363,7 @@ def build_workspace_control_ui(shotgun_panel_name):
         else:
             # The Shotgun app panel that needs to be restored is not in the context configuration.
             engine.logger.error(
-                "Cannot restore %s: SG app panel not found. "
+                "Cannot restore %s: PTR app panel not found. "
                 "Make sure the app is in the context configuration. ",
                 shotgun_panel_name,
             )

--- a/startup/userSetup.py
+++ b/startup/userSetup.py
@@ -34,7 +34,7 @@ def start_toolkit_classic():
     env_engine = os.environ.get("SGTK_ENGINE")
     if not env_engine:
         OpenMaya.MGlobal.displayError(
-            "ShotGrid: Missing required environment variable SGTK_ENGINE."
+            "Flow Production Tracking: Missing required environment variable SGTK_ENGINE."
         )
         return
 
@@ -42,7 +42,7 @@ def start_toolkit_classic():
     env_context = os.environ.get("SGTK_CONTEXT")
     if not env_context:
         OpenMaya.MGlobal.displayError(
-            "ShotGrid: Missing required environment variable SGTK_CONTEXT."
+            "Flow Production Tracking: Missing required environment variable SGTK_CONTEXT."
         )
         return
     try:
@@ -50,7 +50,7 @@ def start_toolkit_classic():
         context = sgtk.context.deserialize(env_context)
     except Exception as e:
         OpenMaya.MGlobal.displayError(
-            "SG: Could not create context! SG Pipeline Toolkit will "
+            "PTR: Could not create context! PTR Pipeline Toolkit will "
             "be disabled. Details: %s" % e
         )
         return
@@ -62,7 +62,9 @@ def start_toolkit_classic():
         )
         sgtk.platform.start_engine(env_engine, context.sgtk, context)
     except Exception as e:
-        OpenMaya.MGlobal.displayError("ShotGrid: Could not start engine: %s" % e)
+        OpenMaya.MGlobal.displayError(
+            "Flow Production Tracking: Could not start engine: %s" % e
+        )
         return
 
 
@@ -109,7 +111,8 @@ def start_toolkit_with_plugins():
             # note: loadPlugin returns a list of the loaded plugins
             if not loaded_plugins:
                 OpenMaya.MGlobal.displayWarning(
-                    "ShotGrid: Could not load plugin: %s" % full_plugin_path
+                    "Flow Production Tracking: Could not load plugin: %s"
+                    % full_plugin_path
                 )
                 continue
 
@@ -125,7 +128,7 @@ def start_toolkit():
         import sgtk
     except Exception as e:
         OpenMaya.MGlobal.displayError(
-            "ShotGrid: Could not import sgtk! Disabling for now: %s" % e
+            "Flow Production Tracking: Could not import sgtk! Disabling for now: %s" % e
         )
         return
 
@@ -142,7 +145,9 @@ def start_toolkit():
     # Check if a file was specified to open and open it.
     file_to_open = os.environ.get("SGTK_FILE_TO_OPEN")
     if file_to_open:
-        OpenMaya.MGlobal.displayInfo("ShotGrid: Opening '%s'..." % file_to_open)
+        OpenMaya.MGlobal.displayInfo(
+            "Flow Production Tracking: Opening '%s'..." % file_to_open
+        )
         cmds.file(file_to_open, force=True, open=True)
 
     # Clean up temp env variables.


### PR DESCRIPTION
merge code from vendor Redesign into FrameEngine's tk-maya repo

Implement fallback to project context and adjust menu callbacks

Updated the exception handling in tk-maya/engine.py to allow for a fallback to the project context when the scene file path is unknown. Additionally, modified the AppCommand class in tk_maya/menu_generation.py to check for existing windows before running the callback, which prevents the creation of duplicate windows.